### PR TITLE
Add filter for holding account purchases list API

### DIFF
--- a/funance/settings.py
+++ b/funance/settings.py
@@ -75,6 +75,7 @@ SECURE_REFERRER_POLICY = "no-referrer-when-downgrade"
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
     "http://localhost:3001",
+    "http://localhost:5173",
 ]
 
 ROOT_URLCONF = "funance.urls"

--- a/holdings/api.py
+++ b/holdings/api.py
@@ -11,6 +11,7 @@ from .serializers import (
     HoldingAccountSerializer,
     HoldingAccountPurchaseSerializer,
     CreateHoldingAccountPurchaseSerializer,
+    HoldingAccountPurchaseRequestSerializer,
 )
 
 
@@ -74,6 +75,22 @@ class HoldingAccountPurchaseViewSet(
             .order_by("-purchased_at")
             .all()
         )
+
+    def filter_queryset(self, queryset):
+        serializer = HoldingAccountPurchaseRequestSerializer(
+            data=self.request.query_params
+        )
+        serializer.is_valid()
+
+        holding_account_pk = serializer.validated_data.get("holding_account")
+        if holding_account_pk:
+            queryset = queryset.filter(holding_account__pk=holding_account_pk)
+
+        ticker_symbol = serializer.validated_data.get("ticker")
+        if ticker_symbol:
+            queryset = queryset.filter(ticker__pk=ticker_symbol)
+
+        return queryset
 
 
 def register_routes(router: BaseRouter):

--- a/holdings/serializers.py
+++ b/holdings/serializers.py
@@ -36,6 +36,20 @@ class CreateHoldingAccountPurchaseSerializer(serializers.ModelSerializer):
         ]
 
 
+class HoldingAccountPurchaseRequestSerializer(serializers.ModelSerializer):
+    holding_account = serializers.UUIDField(required=False)
+    ticker = serializers.CharField(
+        max_length=Ticker.symbol.field.max_length, required=False
+    )
+
+    class Meta:
+        model = HoldingAccountPurchase
+        fields = [
+            "holding_account",
+            "ticker",
+        ]
+
+
 class HoldingAccountPurchaseSerializer(serializers.HyperlinkedModelSerializer):
     ticker = TickerSerializer()
 


### PR DESCRIPTION
- This change adds the HoldingAccountPurchaseRequestSerializer for filtering holding account purchases according to the passed querystring. I've also added tests for this functionality.
- I also added localhost:5173 to the allowed origins because I've switched the UI to use vite rather than react-scripts.