### PR TITLE
Start adding types to the holdings.positions module

### DIFF
--- a/holdings/fidelity.py
+++ b/holdings/fidelity.py
@@ -11,7 +11,8 @@ import dateparser
 
 from holdings.documents import DocumentParser
 from holdings.models import HoldingAccountDocument
-from holdings.positions import PositionAction, PositionGeneration, PositionSet
+from holdings.positions import PositionGeneration, PositionSet
+from holdings.positions.action import PositionAction
 
 
 class StatementParser:

--- a/holdings/models.py
+++ b/holdings/models.py
@@ -6,7 +6,8 @@ from django.utils.translation import gettext_lazy as _
 from typing_extensions import override
 
 from accounts.models import Account
-from holdings.positions import PositionAction, PositionSale
+from holdings.positions import PositionSale
+from holdings.positions.action import PositionAction
 
 
 class HoldingAccount(models.Model):

--- a/holdings/positions/action.py
+++ b/holdings/positions/action.py
@@ -1,0 +1,157 @@
+import datetime
+from decimal import Decimal
+from typing import Literal, TypedDict
+
+from typing_extensions import override
+
+from holdings.positions.common import Copyable, Pythonable
+from holdings.positions.unique import Unique
+
+Action = Literal["buy", "sell"]
+
+
+class PositionActionDict(TypedDict):
+    symbol: str
+    date: datetime.date
+    action: Action
+    quantity: Decimal
+    price: Decimal
+    total: Decimal
+
+
+PositionActionKey = tuple[datetime.date, Action, Decimal, Decimal]
+
+
+class PositionAction(
+    Pythonable["PositionActionDict"],
+    Copyable,
+    Unique,
+):
+    """
+    A single action for a position held in an account.
+    """
+
+    Pythonic = PositionActionDict
+    Key = PositionActionKey
+
+    symbol: str
+    date: datetime.date
+    action: Action
+    quantity: Decimal
+    price: Decimal
+
+    def __init__(
+        self,
+        symbol: str,
+        date: datetime.date,
+        action: Action,
+        quantity: Decimal,
+        price: Decimal,
+    ) -> None:
+        self.symbol = symbol
+        self.date = date
+        self.action = action
+        self.quantity = quantity
+        self.price = price
+
+    def cash_offset(self) -> "PositionAction":
+        """
+        Create the cash offset for this action.
+        """
+        return self.__class__(
+            symbol="CASH",
+            date=self.date,
+            action="sell" if self.action == "buy" else "buy",
+            quantity=self.quantity * self.price,
+            price=Decimal("1"),
+        )
+
+    def add_split(self, new_symbol: str, proportion: Decimal) -> "PositionAction":
+        """
+        Recalculate this action after a split.
+        """
+        return PositionAction(
+            new_symbol,
+            self.date,
+            self.action,
+            quantity=self.quantity * proportion,
+            price=self.price / proportion,
+        )
+
+    def potential_profit(self, price: Decimal) -> Decimal:
+        """
+        Calculate the potential profit from this sale.
+        """
+        return (price - self.price) * self.quantity
+
+    def potential_interest(self, today: datetime.date, price: Decimal) -> Decimal:
+        """
+        Calculate the converted interest of the sale.
+        """
+        days = Decimal((today - self.date).days)
+        year_percent = Decimal("1") if not days else days / Decimal("365.25")
+        return self.potential_profit(price) / self.quantity / self.price / year_percent
+
+    @classmethod
+    def total_profit(
+        cls, price: Decimal, available_purchases: list["PositionAction"]
+    ) -> Decimal:
+        """
+        Determine the total profit of the outstanding position denoted by
+        *available_purchases*.
+        """
+        return Decimal(sum(a.potential_profit(price) for a in available_purchases))
+
+    @classmethod
+    def average_potential_interest(
+        cls,
+        today: datetime.date,
+        price: Decimal,
+        available_purchases: list["PositionAction"],
+    ) -> Decimal:
+        """
+        Determine the average potential interest of the outstanding position
+        denoted by *available_purchases*.
+        """
+        return Decimal(
+            sum(
+                a.potential_interest(today, price) * a.quantity
+                for a in available_purchases
+            )
+        ) / sum(a.quantity for a in available_purchases)
+
+    @override
+    def to_python(self) -> Pythonic:
+        return {
+            "symbol": self.symbol,
+            "date": self.date,
+            "action": self.action,
+            "quantity": self.quantity,
+            "price": self.price,
+            "total": self.quantity * self.price,
+        }
+
+    @classmethod
+    @override
+    def from_python(cls, raw: Pythonic) -> "PositionAction":
+        return cls(
+            raw["symbol"],
+            raw["date"],
+            raw["action"],
+            raw["quantity"],
+            raw["price"],
+        )
+
+    @override
+    def copy(self) -> "PositionAction":
+        return PositionAction(
+            symbol=self.symbol,
+            date=self.date,
+            action=self.action,
+            quantity=self.quantity,
+            price=self.price,
+        )
+
+    @override
+    def key(self) -> "PositionAction.Key":
+        return self.date, self.action, self.quantity, self.price

--- a/holdings/positions/action_list.py
+++ b/holdings/positions/action_list.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+
+from typing_extensions import Self, override
+
+from holdings.positions.action import PositionAction
+from holdings.positions.common import Copyable, Pythonable
+from holdings.positions.unique import UniqueList
+
+PositionActionList = list[PositionAction.Pythonic]
+
+
+class ActionList(
+    UniqueList["PositionAction"],
+    Pythonable["PositionActionList"],
+    Copyable,
+):
+    """
+    Abstraction for operations that can be performed on a ``list`` of
+    :class:`PositionAction` s.
+    """
+
+    Pythonic = PositionActionList
+
+    def add_split(self, new_symbol: str, proportion: Decimal) -> "ActionList":
+        """
+        Apply a split to this position using the given *proportion*
+        """
+        return ActionList(a.add_split(new_symbol, proportion) for a in self)
+
+    @override
+    def append(self, item: PositionAction) -> bool:
+        latest_action = None if len(self) == 0 else self[-1]
+        if latest_action and item.date < latest_action.date:
+            return False
+
+        return super().append(item)
+
+    @classmethod
+    @override
+    def from_python(cls, raw: "ActionList.Pythonic") -> Self:
+        return cls(PositionAction.from_python(a) for a in raw)
+
+    @override
+    def to_python(self) -> "ActionList.Pythonic":
+        return [a.to_python() for a in self]
+
+    @override
+    def copy(self) -> "ActionList":
+        return ActionList(a.copy() for a in self)

--- a/holdings/positions/common.py
+++ b/holdings/positions/common.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from typing_extensions import Self
+
+D = TypeVar("D")
+
+
+class Pythonable(ABC, Generic[D]):
+    """
+    Abstract base class for defining an object that can translate itself to
+    an object and take that same object to recreate itself.
+    """
+
+    @abstractmethod
+    def to_python(self) -> D:
+        """
+        Convert this object to a pythonic object.
+        """
+
+    @classmethod
+    @abstractmethod
+    def from_python(cls, raw: D) -> Self:
+        """
+        Re-create this object from the given object. This is effectively the
+        opposite of the :meth:`to_python` above.
+        """
+
+
+class Copyable(ABC):
+    """
+    Abstract base class for defining an object that can produce a copy of
+    itself.
+    """
+
+    @abstractmethod
+    def copy(self) -> Self:
+        """
+        Return a copy of this action.
+        """

--- a/holdings/positions/test_action.py
+++ b/holdings/positions/test_action.py
@@ -1,0 +1,209 @@
+import datetime
+from decimal import Decimal
+from unittest import TestCase
+
+from holdings.positions.action import PositionAction
+
+
+class PositionActionTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.action = PositionAction(
+            "AAPL",
+            datetime.date(2025, 3, 15),
+            "buy",
+            Decimal("3"),
+            Decimal("234.56"),
+        )
+
+
+class CashOffsetTests(PositionActionTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            {
+                "action": "sell",
+                "date": datetime.date(2025, 3, 15),
+                "price": Decimal("1"),
+                "quantity": Decimal("703.68"),
+                "symbol": "CASH",
+                "total": Decimal("703.68"),
+            },
+            self.action.cash_offset().to_python(),
+        )
+
+
+class AddSplitTests(PositionActionTestCase):
+    def test_split(self) -> None:
+        self.assertEqual(
+            {
+                "action": "buy",
+                "date": datetime.date(2025, 3, 15),
+                "price": Decimal("58.64"),
+                "quantity": Decimal("12"),
+                "symbol": "AAPL2",
+                "total": Decimal("703.68"),
+            },
+            self.action.add_split(
+                "AAPL2",
+                Decimal("4"),
+            ).to_python(),
+        )
+
+    def test_reverse_split(self) -> None:
+        self.assertEqual(
+            {
+                "action": "buy",
+                "date": datetime.date(2025, 3, 15),
+                "price": Decimal("703.6800000000000000000000001"),
+                "quantity": Decimal("0.9999999999999999999999999999"),
+                "symbol": "AAPL2",
+                "total": Decimal("703.68"),
+            },
+            self.action.add_split(
+                "AAPL2",
+                Decimal("1") / 3,
+            ).to_python(),
+        )
+
+
+class PotentialProfitTests(PositionActionTestCase):
+    def test_profit(self) -> None:
+        self.assertEqual(
+            Decimal("136.32"), self.action.potential_profit(Decimal("280.00"))
+        )
+
+    def test_loss(self) -> None:
+        self.assertEqual(
+            Decimal("-103.68"), self.action.potential_profit(Decimal("200.00"))
+        )
+
+
+class PotentialInterestTests(PositionActionTestCase):
+    def test_positive(self) -> None:
+        self.assertEqual(
+            Decimal("0.1938571081500308359341419201"),
+            self.action.potential_interest(
+                self.action.date + datetime.timedelta(days=365),
+                Decimal("280.00"),
+            ),
+        )
+
+    def test_negative(self) -> None:
+        self.assertEqual(
+            Decimal("-0.1474406174662206357808966716"),
+            self.action.potential_interest(
+                self.action.date + datetime.timedelta(days=365),
+                Decimal("200.00"),
+            ),
+        )
+
+
+class TotalProfitTests(PositionActionTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            Decimal("136.32"),
+            PositionAction.total_profit(
+                Decimal("280.00"),
+                [
+                    PositionAction(
+                        "AAPL",
+                        datetime.date(2025, 3, 15),
+                        "buy",
+                        Decimal("1"),
+                        Decimal("234.56"),
+                    ),
+                    PositionAction(
+                        "AAPL",
+                        datetime.date(2025, 3, 15),
+                        "buy",
+                        Decimal("1"),
+                        Decimal("234.56"),
+                    ),
+                    PositionAction(
+                        "AAPL",
+                        datetime.date(2025, 3, 15),
+                        "buy",
+                        Decimal("1"),
+                        Decimal("234.56"),
+                    ),
+                ],
+            ),
+        )
+
+
+class AveragePotentialInterestTests(PositionActionTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            Decimal("0.1938571081500308359341419201"),
+            PositionAction.average_potential_interest(
+                self.action.date + datetime.timedelta(days=365),
+                Decimal("280.00"),
+                [
+                    PositionAction(
+                        "AAPL",
+                        datetime.date(2025, 3, 15),
+                        "buy",
+                        Decimal("1"),
+                        Decimal("234.56"),
+                    ),
+                    PositionAction(
+                        "AAPL",
+                        datetime.date(2025, 3, 15),
+                        "buy",
+                        Decimal("1"),
+                        Decimal("234.56"),
+                    ),
+                    PositionAction(
+                        "AAPL",
+                        datetime.date(2025, 3, 15),
+                        "buy",
+                        Decimal("1"),
+                        Decimal("234.56"),
+                    ),
+                ],
+            ),
+        )
+
+
+class CopyTests(PositionActionTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            {
+                "action": "buy",
+                "date": datetime.date(2025, 3, 15),
+                "price": Decimal("234.56"),
+                "quantity": Decimal("3"),
+                "symbol": "AAPL",
+                "total": Decimal("703.68"),
+            },
+            self.action.copy().to_python(),
+        )
+
+
+class ToPythonTests(PositionActionTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            {
+                "action": "buy",
+                "date": datetime.date(2025, 3, 15),
+                "price": Decimal("234.56"),
+                "quantity": Decimal("3"),
+                "symbol": "AAPL",
+                "total": Decimal("703.68"),
+            },
+            self.action.to_python(),
+        )
+
+
+class KeyTests(PositionActionTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            (
+                datetime.date(2025, 3, 15),
+                "buy",
+                Decimal("3"),
+                Decimal("234.56"),
+            ),
+            self.action.key(),
+        )

--- a/holdings/positions/test_action_list.py
+++ b/holdings/positions/test_action_list.py
@@ -1,0 +1,78 @@
+import datetime
+from decimal import Decimal
+from unittest import TestCase
+
+from holdings.positions.action import PositionAction
+from holdings.positions.action_list import ActionList
+
+
+class ActionListTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.maxDiff = None
+        self.action = PositionAction(
+            "AAPL",
+            datetime.date(2025, 3, 15),
+            "buy",
+            Decimal("3"),
+            Decimal("234.56"),
+        )
+        self.list = ActionList([self.action])
+
+
+class AddSplitTests(ActionListTestCase):
+    def test(self) -> None:
+        self.assertEqual(
+            [
+                {
+                    "action": "buy",
+                    "date": datetime.date(2025, 3, 15),
+                    "price": Decimal("58.64"),
+                    "quantity": Decimal("12"),
+                    "symbol": "AAPL2",
+                    "total": Decimal("703.68"),
+                },
+            ],
+            self.list.add_split(
+                "AAPL2",
+                Decimal("4"),
+            ).to_python(),
+        )
+
+
+class AppendTests(ActionListTestCase):
+    def test_append(self) -> None:
+        self.assertEqual(
+            True,
+            self.list.append(
+                PositionAction(
+                    "AAPL",
+                    datetime.date(2025, 3, 16),
+                    "buy",
+                    Decimal("2"),
+                    Decimal("220.56"),
+                )
+            ),
+        )
+        self.assertEqual(
+            [
+                {
+                    "action": "buy",
+                    "date": datetime.date(2025, 3, 15),
+                    "price": Decimal("234.56"),
+                    "quantity": Decimal("3"),
+                    "symbol": "AAPL",
+                    "total": Decimal("703.68"),
+                },
+                {
+                    "action": "buy",
+                    "date": datetime.date(2025, 3, 16),
+                    "price": Decimal("220.56"),
+                    "quantity": Decimal("2"),
+                    "symbol": "AAPL",
+                    "total": Decimal("441.12"),
+                },
+            ],
+            self.list.to_python(),
+        )

--- a/holdings/positions/test_unique.py
+++ b/holdings/positions/test_unique.py
@@ -1,0 +1,51 @@
+from typing import NamedTuple
+from unittest import TestCase
+
+from holdings.positions.unique import Unique, UniqueList
+
+
+class TestUnique(Unique):
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
+
+    class Key(NamedTuple):
+        a: int
+        b: int
+
+    def key(self) -> "TestUnique.Key":
+        return self.Key(self.a, self.b)
+
+
+class UniqueListTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.list = UniqueList[TestUnique]([])
+
+
+class AppendTests(UniqueListTestCase):
+    def test(self) -> None:
+        self.assertEqual(True, self.list.append(TestUnique(1, 1)))
+        self.assertEqual(False, self.list.append(TestUnique(1, 1)))
+
+
+class GetItemTests(UniqueListTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.list.append(TestUnique(1, 1))
+        self.list.append(TestUnique(2, 2))
+        self.list.append(TestUnique(3, 3))
+
+    def test_index(self) -> None:
+        self.assertEqual(TestUnique.Key(1, 1), self.list[0].key())
+
+    def test_slice(self) -> None:
+        self.assertEqual(
+            [
+                TestUnique.Key(1, 1),
+                TestUnique.Key(2, 2),
+            ],
+            [u.key() for u in self.list[0:2]],
+        )

--- a/holdings/positions/unique.py
+++ b/holdings/positions/unique.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Sequence
+from typing import Any, Generic, TypeVar, overload
+
+from typing_extensions import override
+
+
+class Unique(ABC):
+    """
+    Abstract base class for defining an object that is considered unique.
+    """
+
+    @abstractmethod
+    def key(self) -> tuple[Any, ...]:
+        """
+        Object providing uniqueness to this object.
+        """
+
+
+U = TypeVar("U", bound=Unique)
+
+
+class UniqueList(Sequence[U], Generic[U]):
+    """
+    ``list`` that only appends items that aren't already included
+
+    .. automethod:: append
+    .. automethod:: clear
+    """
+
+    _items: list[U]
+    _item_keys: set[tuple[Any, ...]]
+
+    def __init__(self, items: Iterable[U] | None = None) -> None:
+        self._items = list(items or [])
+        self._item_keys = set(i.key() for i in self._items)
+
+    def append(self, item: U) -> bool:
+        if item.key() in self._item_keys:
+            return False
+        self._items.append(item)
+        self._item_keys.add(item.key())
+        return True
+
+    def clear(self) -> None:
+        """
+        Clear out this list of items
+        """
+        self._items = []
+        self._item_keys = set()
+
+    @overload
+    def __getitem__(self, index: int) -> U: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[U]: ...
+
+    @override
+    def __getitem__(self, index: int | slice) -> U | list[U]:
+        return self._items[index]
+
+    @override
+    def __len__(self) -> int:
+        return len(self._items)


### PR DESCRIPTION
- This change started as a way to standardize the conversion to and from Python but has morphed into an experiment in typing and inheritance.
- I'll be following it up for the same change for sales and generations.